### PR TITLE
Move analytics into head

### DIFF
--- a/twitter/layouts/default.html
+++ b/twitter/layouts/default.html
@@ -28,6 +28,7 @@
     <link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png">
     <link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png">
   -->
+    {{{ widgets.analytics }}}
   </head>
 
   <body>
@@ -62,7 +63,6 @@
     </div> <!-- /container -->
 
     {{{ widgets.google_prettify }}}
-    {{{ widgets.analytics }}}
     
   </body>
 </html>


### PR DESCRIPTION
Google advises that their tracking script appear in the head of your document, preferably at the end.  Along with the updated tracking script commit I submitted to ruhoh.rb, that brings things into line with Google's current guidance.
