### PR TITLE
Enable google_prettify.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -97,5 +97,7 @@ widgets :
     # width: 580
     # colorscheme: light
 
-  google_prettify :
+  syntax :  
+    use : prettify
+    cdn : false
     linenums : true

--- a/twitter/layouts/default.html
+++ b/twitter/layouts/default.html
@@ -61,7 +61,7 @@
 
     </div> <!-- /container -->
 
-    {{{ widgets.google_prettify }}}
+    {{{ widgets.syntax }}}
     {{{ widgets.analytics }}}
     
   </body>


### PR DESCRIPTION
Fix the problem that google_prettify can't be loaded after moving google_prettify into a subdirectory by @caspervonb.
